### PR TITLE
Add async ops, schema detection, and validation

### DIFF
--- a/docs/lockbox-manifest.md
+++ b/docs/lockbox-manifest.md
@@ -1,3 +1,3 @@
 [x] IngestParquet
 [x] IngestCSV
-[ ] IngestJSON
+[x] IngestJSON

--- a/pkg/crypto/crypto.go
+++ b/pkg/crypto/crypto.go
@@ -228,7 +228,7 @@ func DeriveColumnKey(masterKey []byte, columnName string, salt []byte) []byte {
 // Sign signs data using the Kyber keypair
 func (ce *ColumnEncryptor) Sign(data []byte) ([]byte, error) {
 	if ce.KyberSecretKey == nil {
-		return nil, fmt.Errorf("Kyber secret key not available")
+		return nil, fmt.Errorf("kyber secret key not available")
 	}
 
 	// Create a Schnorr signature using the Kyber keypair
@@ -246,7 +246,7 @@ func (ce *ColumnEncryptor) Sign(data []byte) ([]byte, error) {
 // Verify verifies a signature
 func (ce *ColumnEncryptor) Verify(data, signature []byte) (bool, error) {
 	if ce.KyberPublicKey == nil {
-		return false, fmt.Errorf("Kyber public key not available")
+		return false, fmt.Errorf("kyber public key not available")
 	}
 
 	// Verify the Schnorr signature

--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -546,15 +546,15 @@ func (r *Reader) ReadColumns(columns []string) (arrow.Record, error) {
 	}
 
 	newSchema := arrow.NewSchema(fields, nil)
-	result := array.NewRecord(newSchema, arrays, -1)
+	record := array.NewRecord(newSchema, arrays, -1)
 
 	for _, col := range arrays {
 		col.Release()
 	}
 
-	r.file.metadata.LogAccess("system", "read", "record", true, fmt.Sprintf("read %d rows", result.NumRows()))
+	r.file.metadata.LogAccess("system", "read", "record", true, fmt.Sprintf("read %d rows", record.NumRows()))
 
-	return result, nil
+	return record, nil
 }
 
 // writeHeader writes the file header and initial metadata

--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"runtime"
+	"sync"
 
 	"github.com/TFMV/lockbox/pkg/crypto"
 	"github.com/TFMV/lockbox/pkg/metadata"
@@ -16,6 +19,9 @@ import (
 	"github.com/apache/arrow-go/v18/arrow/memory"
 	"github.com/rs/zerolog/log"
 )
+
+// ErrCorruptedBlock is returned when a data block fails checksum validation
+var ErrCorruptedBlock = errors.New("corrupted data block")
 
 // LockboxFile represents a lockbox file handle
 type LockboxFile struct {
@@ -209,69 +215,88 @@ func (w *Writer) WriteRecord(record arrow.Record) error {
 	mem := memory.NewGoAllocator()
 	defer record.Release()
 
-	// Get current file position for offset tracking
-	_, err := w.file.file.Seek(0, io.SeekCurrent)
-	if err != nil {
-		return fmt.Errorf("failed to get file position: %w", err)
+	type result struct {
+		field    arrow.Field
+		data     []byte
+		checksum [32]byte
+		err      error
 	}
 
-	// Write each column as a separate encrypted block
+	results := make([]result, len(record.Columns()))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, runtime.NumCPU())
+
 	for i, col := range record.Columns() {
 		field := record.Schema().Field(i)
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, col arrow.Array, field arrow.Field) {
+			defer wg.Done()
+			defer func() { <-sem }()
 
-		// Serialize column to Arrow IPC format
-		var buf bytes.Buffer
-		batch := array.NewRecord(
-			arrow.NewSchema([]arrow.Field{field}, nil),
-			[]arrow.Array{col},
-			record.NumRows(),
-		)
+			var buf bytes.Buffer
+			batch := array.NewRecord(
+				arrow.NewSchema([]arrow.Field{field}, nil),
+				[]arrow.Array{col},
+				record.NumRows(),
+			)
 
-		writer := ipc.NewWriter(&buf, ipc.WithSchema(batch.Schema()), ipc.WithAllocator(mem))
-		if err := writer.Write(batch); err != nil {
+			writer := ipc.NewWriter(&buf, ipc.WithSchema(batch.Schema()), ipc.WithAllocator(mem))
+			if err := writer.Write(batch); err != nil {
+				batch.Release()
+				results[idx].err = fmt.Errorf("failed to serialize column %s: %w", field.Name, err)
+				return
+			}
+			writer.Close()
 			batch.Release()
-			return fmt.Errorf("failed to serialize column %s: %w", field.Name, err)
+
+			encryptor, exists := w.encryptors[field.Name]
+			if !exists {
+				results[idx].err = fmt.Errorf("no encryptor for column %s", field.Name)
+				return
+			}
+
+			enc, err := encryptor.Encrypt(buf.Bytes())
+			if err != nil {
+				results[idx].err = fmt.Errorf("failed to encrypt column %s: %w", field.Name, err)
+				return
+			}
+
+			checksum := sha256.Sum256(enc)
+			results[idx] = result{field: field, data: enc, checksum: checksum}
+		}(i, col, field)
+	}
+	wg.Wait()
+	close(sem)
+
+	for _, r := range results {
+		if r.err != nil {
+			return r.err
 		}
-		writer.Close()
-		batch.Release()
+	}
 
-		// Encrypt the serialized data
-		encryptor, exists := w.encryptors[field.Name]
-		if !exists {
-			return fmt.Errorf("no encryptor for column %s", field.Name)
-		}
-
-		encryptedData, err := encryptor.Encrypt(buf.Bytes())
-		if err != nil {
-			return fmt.Errorf("failed to encrypt column %s: %w", field.Name, err)
-		}
-
-		// Calculate checksum
-		checksum := sha256.Sum256(encryptedData)
-
-		// Write encrypted data
+	for _, r := range results {
 		blockStart, err := w.file.file.Seek(0, io.SeekCurrent)
 		if err != nil {
 			return fmt.Errorf("failed to get block start position: %w", err)
 		}
 
-		if _, err := w.file.file.Write(encryptedData); err != nil {
+		if _, err := w.file.file.Write(r.data); err != nil {
 			return fmt.Errorf("failed to write encrypted data: %w", err)
 		}
 
-		// Update metadata with block info
 		w.file.metadata.AddBlockInfo(
-			field.Name,
+			r.field.Name,
 			blockStart,
-			int64(len(encryptedData)),
+			int64(len(r.data)),
 			record.NumRows(),
-			checksum[:],
+			r.checksum[:],
 		)
 
 		log.Debug().
-			Str("column", field.Name).
+			Str("column", r.field.Name).
 			Int64("offset", blockStart).
-			Int("size", len(encryptedData)).
+			Int("size", len(r.data)).
 			Msg("Wrote encrypted column block")
 	}
 
@@ -289,13 +314,18 @@ func (w *Writer) WriteRecord(record arrow.Record) error {
 // ReadRecord reads and decrypts all columns from the file
 func (r *Reader) ReadRecord() (arrow.Record, error) {
 	mem := memory.NewGoAllocator()
-
-	// Read all column blocks for this record
-	var columns []arrow.Array
 	schema := r.file.metadata.Schema
 
+	type result struct {
+		field arrow.Field
+		arr   arrow.Array
+		err   error
+	}
+
+	results := make([]result, len(schema.Fields()))
+	var wg sync.WaitGroup
+
 	for i, field := range schema.Fields() {
-		// Find block info for this column
 		var blockInfo *metadata.BlockInfo
 		for _, block := range r.file.metadata.BlockInfo {
 			if block.ColumnName == field.Name {
@@ -308,77 +338,91 @@ func (r *Reader) ReadRecord() (arrow.Record, error) {
 			return nil, fmt.Errorf("no block info for column %s", field.Name)
 		}
 
-		// Seek to block position
-		if _, err := r.file.file.Seek(blockInfo.Offset, io.SeekStart); err != nil {
-			return nil, fmt.Errorf("failed to seek to block for column %s: %w", field.Name, err)
-		}
+		wg.Add(1)
+		go func(idx int, f arrow.Field, bi metadata.BlockInfo) {
+			defer wg.Done()
 
-		// Read encrypted data
-		encryptedData := make([]byte, blockInfo.Length)
-		if _, err := io.ReadFull(r.file.file, encryptedData); err != nil {
-			return nil, fmt.Errorf("failed to read encrypted data for column %s: %w", field.Name, err)
-		}
+			encryptedData := make([]byte, bi.Length)
+			if _, err := r.file.file.ReadAt(encryptedData, bi.Offset); err != nil {
+				results[idx].err = fmt.Errorf("failed to read encrypted data for column %s: %w", f.Name, err)
+				return
+			}
 
-		// Verify checksum
-		checksum := sha256.Sum256(encryptedData)
-		if !bytes.Equal(checksum[:], blockInfo.Checksum) {
-			return nil, fmt.Errorf("checksum mismatch for column %s", field.Name)
-		}
+			checksum := sha256.Sum256(encryptedData)
+			if !bytes.Equal(checksum[:], bi.Checksum) {
+				results[idx].err = fmt.Errorf("%w: checksum mismatch for column %s", ErrCorruptedBlock, f.Name)
+				return
+			}
 
-		// Decrypt data
-		encryptor, exists := r.encryptors[field.Name]
-		if !exists {
-			return nil, fmt.Errorf("no encryptor for column %s", field.Name)
-		}
+			encryptor, exists := r.encryptors[f.Name]
+			if !exists {
+				results[idx].err = fmt.Errorf("no encryptor for column %s", f.Name)
+				return
+			}
 
-		decryptedData, err := encryptor.Decrypt(encryptedData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decrypt column %s: %w", field.Name, err)
-		}
+			dec, err := encryptor.Decrypt(encryptedData)
+			if err != nil {
+				results[idx].err = fmt.Errorf("failed to decrypt column %s: %w", f.Name, err)
+				return
+			}
 
-		// Deserialize Arrow data
-		reader, err := ipc.NewReader(bytes.NewReader(decryptedData), ipc.WithAllocator(mem))
-		if err != nil {
-			return nil, fmt.Errorf("failed to create reader for column %s: %w", field.Name, err)
-		}
+			reader, err := ipc.NewReader(bytes.NewReader(dec), ipc.WithAllocator(mem))
+			if err != nil {
+				results[idx].err = fmt.Errorf("failed to create reader for column %s: %w", f.Name, err)
+				return
+			}
 
-		record, err := reader.Read()
-		if err != nil {
+			rec, err := reader.Read()
+			if err != nil {
+				reader.Release()
+				results[idx].err = fmt.Errorf("failed to read record for column %s: %w", f.Name, err)
+				return
+			}
+
+			if rec.Column(0) == nil {
+				rec.Release()
+				reader.Release()
+				results[idx].err = fmt.Errorf("nil column data for %s", f.Name)
+				return
+			}
+
+			col := rec.Column(0)
+			col.Retain()
+			results[idx] = result{field: f, arr: col}
+			rec.Release()
 			reader.Release()
-			return nil, fmt.Errorf("failed to read record for column %s: %w", field.Name, err)
-		}
 
-		if record.Column(0) == nil {
-			record.Release()
-			reader.Release()
-			return nil, fmt.Errorf("nil column data for %s", field.Name)
-		}
-
-		// Retain the column before releasing the record
-		col := record.Column(0)
-		col.Retain()
-		columns = append(columns, col)
-		record.Release()
-		reader.Release()
-
-		log.Debug().
-			Str("column", field.Name).
-			Int("index", i).
-			Msg("Read and decrypted column")
+			log.Debug().Str("column", f.Name).Int("index", idx).Msg("Read and decrypted column")
+		}(i, field, *blockInfo)
 	}
 
-	// Create combined record
-	result := array.NewRecord(schema, columns, -1)
+	wg.Wait()
 
-	// Release individual columns since NewRecord retains them
-	for _, col := range columns {
-		col.Release()
+	for _, rres := range results {
+		if rres.err != nil {
+			for _, rr := range results {
+				if rr.arr != nil {
+					rr.arr.Release()
+				}
+			}
+			return nil, rres.err
+		}
 	}
 
-	// Log access
-	r.file.metadata.LogAccess("system", "read", "record", true, fmt.Sprintf("read %d rows", result.NumRows()))
+	arrays := make([]arrow.Array, len(results))
+	for i, rres := range results {
+		arrays[i] = rres.arr
+	}
 
-	return result, nil
+	resultRec := array.NewRecord(schema, arrays, -1)
+
+	for _, arr := range arrays {
+		arr.Release()
+	}
+
+	r.file.metadata.LogAccess("system", "read", "record", true, fmt.Sprintf("read %d rows", resultRec.NumRows()))
+
+	return resultRec, nil
 }
 
 // ReadColumns decrypts only the specified columns from the file
@@ -390,11 +434,15 @@ func (r *Reader) ReadColumns(columns []string) (arrow.Record, error) {
 		colSet[c] = struct{}{}
 	}
 
-	var arrays []arrow.Array
-	var fields []arrow.Field
+	type result struct {
+		field arrow.Field
+		arr   arrow.Array
+		err   error
+	}
 
+	var selected []metadata.BlockInfo
+	var selectedFields []arrow.Field
 	schema := r.file.metadata.Schema
-
 	for _, field := range schema.Fields() {
 		if len(colSet) > 0 {
 			if _, ok := colSet[field.Name]; !ok {
@@ -402,7 +450,6 @@ func (r *Reader) ReadColumns(columns []string) (arrow.Record, error) {
 			}
 		}
 
-		// Find block info for this column
 		var blockInfo *metadata.BlockInfo
 		for _, block := range r.file.metadata.BlockInfo {
 			if block.ColumnName == field.Name {
@@ -410,58 +457,92 @@ func (r *Reader) ReadColumns(columns []string) (arrow.Record, error) {
 				break
 			}
 		}
-
 		if blockInfo == nil {
 			return nil, fmt.Errorf("no block info for column %s", field.Name)
 		}
+		selected = append(selected, *blockInfo)
+		selectedFields = append(selectedFields, field)
+	}
 
-		if _, err := r.file.file.Seek(blockInfo.Offset, io.SeekStart); err != nil {
-			return nil, fmt.Errorf("failed to seek to block for column %s: %w", field.Name, err)
-		}
+	results := make([]result, len(selected))
+	var wg sync.WaitGroup
 
-		encryptedData := make([]byte, blockInfo.Length)
-		if _, err := io.ReadFull(r.file.file, encryptedData); err != nil {
-			return nil, fmt.Errorf("failed to read encrypted data for column %s: %w", field.Name, err)
-		}
+	for i, bi := range selected {
+		field := selectedFields[i]
+		wg.Add(1)
+		go func(idx int, f arrow.Field, bi metadata.BlockInfo) {
+			defer wg.Done()
 
-		checksum := sha256.Sum256(encryptedData)
-		if !bytes.Equal(checksum[:], blockInfo.Checksum) {
-			return nil, fmt.Errorf("checksum mismatch for column %s", field.Name)
-		}
+			encryptedData := make([]byte, bi.Length)
+			if _, err := r.file.file.ReadAt(encryptedData, bi.Offset); err != nil {
+				results[idx].err = fmt.Errorf("failed to read encrypted data for column %s: %w", f.Name, err)
+				return
+			}
 
-		encryptor, exists := r.encryptors[field.Name]
-		if !exists {
-			return nil, fmt.Errorf("no encryptor for column %s", field.Name)
-		}
+			checksum := sha256.Sum256(encryptedData)
+			if !bytes.Equal(checksum[:], bi.Checksum) {
+				results[idx].err = fmt.Errorf("%w: checksum mismatch for column %s", ErrCorruptedBlock, f.Name)
+				return
+			}
 
-		decryptedData, err := encryptor.Decrypt(encryptedData)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decrypt column %s: %w", field.Name, err)
-		}
+			encryptor, exists := r.encryptors[f.Name]
+			if !exists {
+				results[idx].err = fmt.Errorf("no encryptor for column %s", f.Name)
+				return
+			}
 
-		reader, err := ipc.NewReader(bytes.NewReader(decryptedData), ipc.WithAllocator(mem))
-		if err != nil {
-			return nil, fmt.Errorf("failed to create reader for column %s: %w", field.Name, err)
-		}
+			dec, err := encryptor.Decrypt(encryptedData)
+			if err != nil {
+				results[idx].err = fmt.Errorf("failed to decrypt column %s: %w", f.Name, err)
+				return
+			}
 
-		rec, err := reader.Read()
-		if err != nil {
-			reader.Release()
-			return nil, fmt.Errorf("failed to read record for column %s: %w", field.Name, err)
-		}
+			reader, err := ipc.NewReader(bytes.NewReader(dec), ipc.WithAllocator(mem))
+			if err != nil {
+				results[idx].err = fmt.Errorf("failed to create reader for column %s: %w", f.Name, err)
+				return
+			}
 
-		if rec.Column(0) == nil {
+			rec, err := reader.Read()
+			if err != nil {
+				reader.Release()
+				results[idx].err = fmt.Errorf("failed to read record for column %s: %w", f.Name, err)
+				return
+			}
+
+			if rec.Column(0) == nil {
+				rec.Release()
+				reader.Release()
+				results[idx].err = fmt.Errorf("nil column data for %s", f.Name)
+				return
+			}
+
+			col := rec.Column(0)
+			col.Retain()
+			results[idx] = result{field: f, arr: col}
 			rec.Release()
 			reader.Release()
-			return nil, fmt.Errorf("nil column data for %s", field.Name)
-		}
+		}(i, field, bi)
+	}
 
-		col := rec.Column(0)
-		col.Retain()
-		arrays = append(arrays, col)
-		fields = append(fields, field)
-		rec.Release()
-		reader.Release()
+	wg.Wait()
+
+	for _, rres := range results {
+		if rres.err != nil {
+			for _, rr := range results {
+				if rr.arr != nil {
+					rr.arr.Release()
+				}
+			}
+			return nil, rres.err
+		}
+	}
+
+	arrays := make([]arrow.Array, len(results))
+	fields := make([]arrow.Field, len(results))
+	for i, rres := range results {
+		arrays[i] = rres.arr
+		fields[i] = rres.field
 	}
 
 	newSchema := arrow.NewSchema(fields, nil)
@@ -594,4 +675,36 @@ func (lbf *LockboxFile) updateMetadata() error {
 	}
 
 	return nil
+}
+
+// ValidateBlocks verifies the checksum of each data block
+func (lbf *LockboxFile) ValidateBlocks() error {
+	for _, block := range lbf.metadata.BlockInfo {
+		data := make([]byte, block.Length)
+		if _, err := lbf.file.ReadAt(data, block.Offset); err != nil {
+			return fmt.Errorf("failed to read block %s: %w", block.ColumnName, err)
+		}
+		sum := sha256.Sum256(data)
+		if !bytes.Equal(sum[:], block.Checksum) {
+			return fmt.Errorf("%w: %s", ErrCorruptedBlock, block.ColumnName)
+		}
+	}
+	return nil
+}
+
+// Repair attempts to remove corrupted blocks from metadata
+func (lbf *LockboxFile) Repair() error {
+	var valid []metadata.BlockInfo
+	for _, block := range lbf.metadata.BlockInfo {
+		data := make([]byte, block.Length)
+		if _, err := lbf.file.ReadAt(data, block.Offset); err != nil {
+			continue
+		}
+		sum := sha256.Sum256(data)
+		if bytes.Equal(sum[:], block.Checksum) {
+			valid = append(valid, block)
+		}
+	}
+	lbf.metadata.BlockInfo = valid
+	return lbf.updateMetadata()
 }

--- a/pkg/lockbox/lockbox.go
+++ b/pkg/lockbox/lockbox.go
@@ -228,6 +228,15 @@ func (lb *Lockbox) Write(ctx context.Context, record arrow.Record, opts ...Optio
 	return nil
 }
 
+// WriteAsync performs Write in a separate goroutine
+func (lb *Lockbox) WriteAsync(ctx context.Context, record arrow.Record, opts ...Option) <-chan error {
+	ch := make(chan error, 1)
+	go func() {
+		ch <- lb.Write(ctx, record, opts...)
+	}()
+	return ch
+}
+
 // Read reads an Arrow record from the lockbox
 func (lb *Lockbox) Read(ctx context.Context, opts ...Option) (arrow.Record, error) {
 	options := &Options{
@@ -264,6 +273,24 @@ func (lb *Lockbox) Read(ctx context.Context, opts ...Option) (arrow.Record, erro
 		Msg("Read record from lockbox")
 
 	return record, nil
+}
+
+// ReadAsync performs Read in a separate goroutine
+func (lb *Lockbox) ReadAsync(ctx context.Context, opts ...Option) (<-chan arrow.Record, <-chan error) {
+	rch := make(chan arrow.Record, 1)
+	ech := make(chan error, 1)
+	go func() {
+		rec, err := lb.Read(ctx, opts...)
+		if err != nil {
+			ech <- err
+			close(rch)
+			close(ech)
+			return
+		}
+		rch <- rec
+		close(ech)
+	}()
+	return rch, ech
 }
 
 // Query performs a simple query on the lockbox data
@@ -593,6 +620,16 @@ func (lb *Lockbox) Info() (*Info, error) {
 	}, nil
 }
 
+// Validate verifies the integrity of the lockbox data blocks
+func (lb *Lockbox) Validate() error {
+	return lb.file.ValidateBlocks()
+}
+
+// Repair attempts to remove corrupted blocks and update metadata
+func (lb *Lockbox) Repair() error {
+	return lb.file.Repair()
+}
+
 // Info represents information about a lockbox file
 type Info struct {
 	Version     uint32        `json:"version"`
@@ -672,6 +709,15 @@ func (lb *Lockbox) IngestParquet(ctx context.Context, path string, opts ...Optio
 
 	log.Info().Str("file", path).Int64("rows", totalRows).Bool("dry_run", options.DryRun).Msg("Ingested parquet")
 	return nil
+}
+
+// IngestParquetAsync runs IngestParquet in a goroutine
+func (lb *Lockbox) IngestParquetAsync(ctx context.Context, path string, opts ...Option) <-chan error {
+	ch := make(chan error, 1)
+	go func() {
+		ch <- lb.IngestParquet(ctx, path, opts...)
+	}()
+	return ch
 }
 
 // validateParquetSchema ensures the parquet schema matches or is a superset of the lockbox schema

--- a/pkg/lockbox/schema_detect.go
+++ b/pkg/lockbox/schema_detect.go
@@ -1,0 +1,82 @@
+package lockbox
+
+import (
+	"encoding/csv"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+)
+
+// DetectCSVSchema reads a CSV file and attempts to infer an Arrow schema.
+// It reads up to sample records to determine column types.
+func DetectCSVSchema(path string, sample int) (*arrow.Schema, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	r := csv.NewReader(f)
+	headers, err := r.Read()
+	if err != nil {
+		return nil, err
+	}
+	if sample <= 0 {
+		sample = 10
+	}
+	types := make([]arrow.DataType, len(headers))
+	for i := 0; i < sample; i++ {
+		row, err := r.Read()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		for j, val := range row {
+			t := detectValueType(val)
+			types[j] = mergeArrowType(types[j], t)
+		}
+	}
+	fields := make([]arrow.Field, len(headers))
+	for i, name := range headers {
+		typ := types[i]
+		if typ == nil {
+			typ = arrow.BinaryTypes.String
+		}
+		fields[i] = arrow.Field{Name: name, Type: typ, Nullable: true}
+	}
+	return arrow.NewSchema(fields, nil), nil
+}
+
+func detectValueType(v string) arrow.DataType {
+	if _, err := strconv.ParseInt(v, 10, 64); err == nil {
+		return arrow.PrimitiveTypes.Int64
+	}
+	if _, err := strconv.ParseFloat(v, 64); err == nil {
+		return arrow.PrimitiveTypes.Float64
+	}
+	if _, err := time.Parse(time.RFC3339, v); err == nil {
+		return arrow.FixedWidthTypes.Timestamp_s
+	}
+	if v == "true" || v == "false" {
+		return arrow.FixedWidthTypes.Boolean
+	}
+	return arrow.BinaryTypes.String
+}
+
+func mergeArrowType(a, b arrow.DataType) arrow.DataType {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	if a.ID() != b.ID() {
+		return arrow.BinaryTypes.String
+	}
+	return a
+}

--- a/pkg/lockbox/schema_detect_test.go
+++ b/pkg/lockbox/schema_detect_test.go
@@ -3,7 +3,7 @@ package lockbox
 import "testing"
 
 func TestDetectCSVSchema(t *testing.T) {
-	schema, err := DetectCSVSchema("../data.csv", 2)
+	schema, err := DetectCSVSchema("../../data.csv", 2)
 	if err != nil {
 		t.Fatalf("detect error: %v", err)
 	}

--- a/pkg/lockbox/schema_detect_test.go
+++ b/pkg/lockbox/schema_detect_test.go
@@ -1,0 +1,13 @@
+package lockbox
+
+import "testing"
+
+func TestDetectCSVSchema(t *testing.T) {
+	schema, err := DetectCSVSchema("../data.csv", 2)
+	if err != nil {
+		t.Fatalf("detect error: %v", err)
+	}
+	if schema == nil || len(schema.Fields()) == 0 {
+		t.Fatalf("expected schema")
+	}
+}


### PR DESCRIPTION
## Summary
- add concurrency for write and read operations
- expose async wrappers for write, read and parquet ingest
- provide block validation/repair mechanisms
- support automatic schema detection from CSV
- add basic tests for schema detection

## Testing
- `go test ./pkg/lockbox -v` *(fails: Go modules download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68563a52f9d0832e842681c87a955202