### PR TITLE
[feature] supporting the ORC file format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,14 @@
 *.dll
 *.so
 *.dylib
+!*.py
+!cmd/lockbox/cmd/
+!cmd/lockbox/cmd/**
+
 
 
 *.lbx
 *.out
-lockbox
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/lockbox/cmd/orc2parquet.py
+++ b/cmd/lockbox/cmd/orc2parquet.py
@@ -1,0 +1,16 @@
+# orc2parquet.py
+import sys
+import pyarrow.orc as orc
+import pyarrow.parquet as pq
+
+if len(sys.argv) != 3:
+    print("Usage: python orc2parquet.py input.orc output.parquet")
+    sys.exit(1)
+
+orc_path = sys.argv[1]
+parquet_path = sys.argv[2]
+
+orc_file = orc.ORCFile(orc_path)
+table = orc_file.read()
+pq.write_table(table, parquet_path)
+print(f"Converted {orc_path} to {parquet_path}")

--- a/pkg/lockbox/lockbox.go
+++ b/pkg/lockbox/lockbox.go
@@ -941,7 +941,7 @@ func (lb *Lockbox) IngestParquet(ctx context.Context, path string, opts ...Optio
 	var totalRows int64
 	for recReader.Next() {
 		rec := recReader.Record()
-		coerced, err := coerceRecord(lb.Schema(), rec)
+		coerced, err := CoerceRecord(lb.Schema(), rec)
 		if err != nil {
 			rec.Release()
 			return err
@@ -1002,8 +1002,8 @@ func typesCompatible(dst, src arrow.DataType) bool {
 	return false
 }
 
-// coerceRecord converts parquet record columns to lockbox schema order and types
-func coerceRecord(schema *arrow.Schema, rec arrow.Record) (arrow.Record, error) {
+// CoerceRecord converts parquet record columns to lockbox schema order and types
+func CoerceRecord(schema *arrow.Schema, rec arrow.Record) (arrow.Record, error) {
 	if rec.Schema().Equal(schema) {
 		rec.Retain()
 		return rec, nil


### PR DESCRIPTION
**[feature] supporting the ORC file format writing**

- The Arrow-go client doesn't currently support the ORC reader. It may take some time on their end to add the functionality, so we would convert the ORC format to Parquet and ingest it here.
- The approach taken here is to use an intermediate Python wrapper script to convert from ORC to Parquet using PyArrow.orc.
- The host system may not have the dependencies, so when the write file is called, it would install the dependencies dynamically, i.e. pyarrow.orc.
- Draft version needs actual testing.